### PR TITLE
Import lib from github.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
 env
 .backlog-cli.*
+backlog-cli
 node_modules/

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@
 
 package main
 
-import "backlog-cli/cmd"
+import "github.com/aflashyrhetoric/backlog-cli/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Can we import lib from github.com instead of local path?
I think its standard way to import from github.com (where the repo exists).
